### PR TITLE
SQL Dialect System Implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+# macOS
+.DS_Store
+
+# Python
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.Python
+build/
+dist/
+*.egg-info/
+venv/
+.env
+
+docs/
+test_*.py

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # Meterstick Documentation
 
 The meterstick package provides a concise syntax to describe and execute
-routine data analysis tasks. Please see [meterstick_demo.ipynb](https://colab.research.google.com/github/google/meterstick/blob/master/meterstick_demo.ipynb) for examples.
+routine data analysis tasks. Meterstick supports multiple SQL dialects, including BigQuery (default) and Trino, allowing you to generate SQL compatible with different database systems while maintaining a unified Python API.
+
+Please see [meterstick_demo.ipynb](https://colab.research.google.com/github/google/meterstick/blob/master/meterstick_demo.ipynb) for examples.
 
 ## Disclaimer
 
@@ -307,9 +309,34 @@ It can help you to sanity check complex Metrics.
 
 You can get the SQL query for all built-in Metrics and Operations by calling
 `to_sql(sql_data_source, split_by)` on the Metric. `sql_data_source` could be a
-table or a subquery. The dialect it uses is the
+table or a subquery. 
+
+### SQL Dialects
+
+Meterstick supports multiple SQL dialects. By default, it generates BigQuery-compatible SQL, but you can switch to other dialects:
+
+```python
+from meterstick import *
+
+# Set SQL dialect (default is 'bigquery')
+set_sql_dialect('trino')
+
+# Your metrics will now generate Trino-compatible SQL
+revenue_per_user = Sum('revenue') / Count('user_id')
+sql = revenue_per_user.to_sql('user_events')
+```
+
+**Supported Dialects:**
+- `bigquery` (default): Google BigQuery SQL syntax
+- `trino`: Trino/Presto SQL syntax
+
+You can also register custom dialects for other database systems by creating a class that inherits from `SqlDialect` and calling `register_sql_dialect(your_dialect)`.
+
+### SQL Examples
+
+The dialect it uses is the
 [standard SQL](https://cloud.google.com/bigquery/docs/reference/standard-sql)
-in Google Cloud's BigQuery. For example,
+in Google Cloud's BigQuery by default. For example,
 
 ```python
 MetricList((Sum('X', where='Y > 0'), Sum('X'))).to_sql('table', 'grp')

--- a/__init__.py
+++ b/__init__.py
@@ -21,3 +21,4 @@ from meterstick.diversity import *
 from meterstick.metrics import *
 from meterstick.operations import *
 from meterstick.sql import *
+from meterstick.sql_dialect import *

--- a/metrics_test.py
+++ b/metrics_test.py
@@ -534,8 +534,8 @@ class TestCompositeMetric(absltest.TestCase):
         'Condition': [0, 0, 0, 1, 1, 1],
         'grp': ['A', 'A', 'B', 'A', 'B', 'C']
     })
-    suma = metrics.Sum('X', where='grp == "A"')
-    sumb = metrics.Sum('X', where='grp == "B"')
+    suma = metrics.Sum('X', where="grp == 'A'")
+    sumb = metrics.Sum('X', where="grp == 'B'")
     pct = operations.PercentChange('Condition', 0)
     output = (pct(suma) - pct(sumb)).compute_on(df)
     expected = pct(suma).compute_on(df) - pct(sumb).compute_on(df)
@@ -558,8 +558,8 @@ class TestCompositeMetric(absltest.TestCase):
         'grp': ['A', 'A', 'B', 'A', 'B', 'C']
     })
     sumx = metrics.Sum('X')
-    pcta = operations.PercentChange('Condition', 0, sumx, where='grp == "A"')
-    pctb = operations.PercentChange('Condition', 0, sumx, where='grp == "B"')
+    pcta = operations.PercentChange('Condition', 0, sumx, where="grp == 'A'")
+    pctb = operations.PercentChange('Condition', 0, sumx, where="grp == 'B'")
     output = (pcta - pctb).compute_on(df)
     expected = pcta.compute_on(df) - pctb.compute_on(df)
     expected.columns = ['%s - %s' % (c, c) for c in expected.columns]
@@ -574,10 +574,10 @@ class TestCompositeMetric(absltest.TestCase):
     })
     np.random.seed(42)
     sumx = metrics.Sum('X')
-    pcta = operations.PercentChange('Condition', 0, sumx, where='grp == "A"')
+    pcta = operations.PercentChange('Condition', 0, sumx, where="grp == 'A'")
     pctb = operations.PercentChange('Condition', 0, sumx)
     jk = operations.Jackknife('cookie', pcta)
-    bst = operations.Bootstrap(None, pctb, 20, where='grp != "C"')
+    bst = operations.Bootstrap(None, pctb, 20, where="grp != 'C'")
     m = (jk / bst).rename_columns(
         pd.MultiIndex.from_product((('sum(X)',), ('Value', 'SE'))))
     output = m.compute_on(df)
@@ -635,8 +635,8 @@ class TestCompositeMetric(absltest.TestCase):
 
   def test_duplicate_column_names(self):
     df = pd.DataFrame({'g': ['a', 'b'], 'x': [1, 3]})
-    a = metrics.Sum('x', where='g == "a"')
-    b = metrics.Sum('x', where='g == "b"')
+    a = metrics.Sum('x', where="g == 'a'")
+    b = metrics.Sum('x', where="g == 'b'")
     output = (metrics.MetricList((a, b)) / (a + b)).compute_on(df)
     expected = pd.DataFrame(
         [[0.25, 0.75]], columns=['sum(x) / sum(x) + sum(x)'] * 2
@@ -714,17 +714,17 @@ class TestMetricList(parameterized.TestCase):
     testing.assert_frame_equal(output, expected)
 
   def test_unwrap(self):
-    s = metrics.Sum('x', where='bar')
+    s = metrics.Sum('x', where="bar")
     m = metrics.MetricList([s, metrics.Count('y')])
-    m = metrics.MetricList([m, metrics.Sum('z')], where='foo')
+    m = metrics.MetricList([m, metrics.Sum('z')], where="foo")
     actual = m.unwrap()
     expected = [
-        metrics.Sum('x', where=('bar', 'foo')),
-        metrics.Count('y', where='foo'),
-        metrics.Sum('z', where='foo'),
+        metrics.Sum('x', where=("bar", "foo")),
+        metrics.Count('y', where="foo"),
+        metrics.Sum('z', where="foo"),
     ]
     self.assertEqual(actual, expected)
-    self.assertEqual(s.where, 'bar')  # orignal instance is not changed
+    self.assertEqual(s.where, "bar")  # orignal instance is not changed
 
   def test_len(self):
     ms = [metrics.Sum('X'), metrics.Mean('X')]
@@ -790,10 +790,10 @@ class TestMetricList(parameterized.TestCase):
 
   def test_to_dot(self):
     m0 = 1
-    m1 = metrics.Sum('x', where='foo')
+    m1 = metrics.Sum('x', where="foo")
     m2 = m0 + m1
     m3 = metrics.Sum('y')
-    m4 = metrics.Count('z', where='bar')
+    m4 = metrics.Count('z', where="bar")
     m5 = m3 / m4
     m6 = metrics.MetricList((m2, m5))
     m6.name = 'baz'

--- a/models.py
+++ b/models.py
@@ -25,6 +25,7 @@ from meterstick import metrics
 from meterstick import operations
 from meterstick import sql
 from meterstick import utils
+from meterstick import sql_dialect
 import numpy as np
 import pandas as pd
 from sklearn import linear_model
@@ -1152,7 +1153,7 @@ class LogisticRegression(Model):
         for cond, slice_coef, done in zip(conds, coef, converged):
           if not done:
             condition = [
-                f'{c} = "{v}"' if isinstance(v, str) else f'{c} = {v}'
+                f"{c} = '{v}'" if isinstance(v, str) else f'{c} = {v}'
                 for c, v in zip(split_cols, cond)
             ]
             condition = ' AND '.join(condition)
@@ -1232,7 +1233,8 @@ class LogisticRegression(Model):
       # https://colab.research.google.com/drive/1Srfs4weM4LO9vt1HbOkGrD4kVbG8cso8
       # For 'l1' and 'elasticnet', we use FISTA, which uses unregularized
       # gradient.
-      n = f'COUNTIF({condition})' if condition else 'COUNT(*)'
+      dialect = sql_dialect.get_sql_dialect()
+      n = dialect.count_if(condition) if condition else 'COUNT(*)'
       if self.penalty == 'l2':
         for i in range(self.k):
           grads[i] += sql.Column(f'{coef[i]} / {n}') / self.c

--- a/operations_test.py
+++ b/operations_test.py
@@ -1867,8 +1867,7 @@ class BootstrapTests(parameterized.TestCase):
   def test_bootstrap_no_unit_where(self):
     df = pd.DataFrame({'x': range(1, 7), 'grp': ['B'] * 3 + ['A'] * 3})
     metric = operations.Bootstrap(
-        None, metrics.Sum('x'), self.n, where='grp == "A"'
-    )
+        None, metrics.Sum('x'), self.n, where="grp == 'A'")
     metric_no_filter = operations.Bootstrap(None, metrics.Sum('x'), self.n)
     np.random.seed(42)
     output = metric.compute_on(df)

--- a/sql_dialect.py
+++ b/sql_dialect.py
@@ -1,0 +1,411 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""SQL Dialect system for cross-platform SQL generation."""
+
+from abc import ABC, abstractmethod
+
+from typing import Optional, Dict, Union, List
+
+
+class SqlDialect(ABC):
+    """Abstract base class for SQL dialect implementations.
+    
+    This class defines the interface that all SQL dialects must implement
+    to support cross-platform SQL generation in meterstick.
+    """
+    
+    @property
+    @abstractmethod
+    def name(self) -> str:
+        """Return the name of this SQL dialect (e.g., 'bigquery', 'trino')."""
+        pass
+    
+    # Division operations
+    @abstractmethod
+    def safe_divide(self, numerator: str, denominator: str) -> str:
+        """Generate safe division SQL that handles division by zero.
+        
+        Args:
+            numerator: SQL expression for the numerator
+            denominator: SQL expression for the denominator
+            
+        Returns:
+            SQL expression that safely divides numerator by denominator,
+            returning NULL when denominator is zero.
+        """
+        pass
+    
+    # Quantile functions
+    @abstractmethod
+    def approx_quantile(self, column: str, quantile: float) -> str:
+        """Generate approximate quantile calculation SQL.
+        
+        Args:
+            column: Column expression to calculate quantile for
+            quantile: Quantile value between 0 and 1
+            
+        Returns:
+            SQL expression that calculates the approximate quantile.
+        """
+        pass
+    
+    # Array operations
+    @abstractmethod
+    def array_agg_with_limit(self, column: str, order_by: str, limit: int, offset: int) -> str:
+        """Generate array aggregation with limit and offset.
+        
+        Args:
+            column: Column to aggregate
+            order_by: ORDER BY clause expression
+            limit: Maximum number of elements to include
+            offset: Zero-based offset for element selection
+            
+        Returns:
+            SQL expression for array aggregation with indexing.
+        """
+        pass
+    
+    @abstractmethod
+    def array_agg_ignore_nulls(self, column: str, order_by: str) -> str:
+        """Generate array aggregation ignoring NULL values.
+        
+        Args:
+            column: Column to aggregate
+            order_by: ORDER BY clause expression
+            
+        Returns:
+            SQL expression for array aggregation without NULLs.
+        """
+        pass
+    
+    # Conditional counting
+    @abstractmethod
+    def count_if(self, condition: str) -> str:
+        """Generate conditional counting SQL.
+        
+        Args:
+            condition: Boolean condition expression
+            
+        Returns:
+            SQL expression that counts rows where condition is true.
+        """
+        pass
+    
+    # Data type casting
+    @abstractmethod
+    def cast_to_string(self, column: str) -> str:
+        """Cast column to string/text type.
+        
+        Args:
+            column: Column expression to cast
+            
+        Returns:
+            SQL expression that casts column to string type.
+        """
+        pass
+    
+    # Mathematical functions
+    @abstractmethod
+    def safe_power(self, base: str, exponent: str) -> str:
+        """Generate safe power function SQL.
+        
+        Args:
+            base: Base expression
+            exponent: Exponent expression
+            
+        Returns:
+            SQL expression for power calculation.
+        """
+        pass
+    
+    @abstractmethod
+    def safe_sqrt(self, value: str) -> str:
+        """Generate safe square root function SQL.
+        
+        Args:
+            value: Value expression
+            
+        Returns:
+            SQL expression for square root calculation.
+        """
+        pass
+    
+    # Array generation and unnest
+    @abstractmethod
+    def generate_array(self, start: int, end: int) -> str:
+        """Generate array sequence from start to end.
+        
+        Args:
+            start: Start value (inclusive)
+            end: End value (inclusive)
+            
+        Returns:
+            SQL expression that generates an array sequence.
+        """
+        pass
+    
+    @abstractmethod
+    def unnest_with_alias(self, array_expr: str, alias: str) -> str:
+        """Generate UNNEST with proper alias syntax.
+        
+        Args:
+            array_expr: Array expression to unnest
+            alias: Alias for the unnested values
+            
+        Returns:
+            SQL expression for UNNEST with alias.
+        """
+        pass
+    
+    @abstractmethod
+    def nth_value_with_ignore_nulls(self, column: str, sort_by: str, n: int, ascending: bool = True) -> str:
+        """Generate nth value with ignore nulls SQL.
+        
+        Args:
+            column: Column expression to get nth value from
+            sort_by: Column to sort by
+            n: Zero-based index (0 = first, 1 = second, etc.)
+            ascending: Whether to sort in ascending order
+            
+        Returns:
+            SQL expression that gets the nth value ignoring nulls.
+        """
+        pass
+
+    # PoissonBootstrap-specific operations
+    @abstractmethod
+    def poisson_bootstrap_uniform_hash(self, columns: List[str]) -> str:
+        """Generate uniform random variable for PoissonBootstrap using consistent hashing.
+        
+        Args:
+            columns: List of column expressions to include in hash
+            
+        Returns:
+            SQL expression that generates a uniform random variable [0,1) 
+            using consistent hashing of the columns.
+        """
+        pass
+    
+    @abstractmethod
+    def select_all_except(self, excluded_columns: List[str]) -> str:
+        """Generate SQL to select all columns except specified ones.
+        
+        Args:
+            excluded_columns: List of column names to exclude
+            
+        Returns:
+            SQL expression that selects all columns except the excluded ones.
+        """
+        pass
+
+
+class BigQueryDialect(SqlDialect):
+    """BigQuery SQL dialect implementation.
+    
+    This maintains the original BigQuery-specific SQL generation behavior
+    to ensure backwards compatibility.
+    """
+    
+    @property
+    def name(self) -> str:
+        return "bigquery"
+    
+    def safe_divide(self, numerator: str, denominator: str) -> str:
+        return f'IF(({denominator}) = 0, NULL, ({numerator}) / ({denominator}))'
+    
+    def approx_quantile(self, column: str, quantile: float) -> str:
+        offset = int(100 * quantile)
+        return f'APPROX_QUANTILES({column}, 100)[OFFSET({offset})]'
+    
+    def array_agg_with_limit(self, column: str, order_by: str, limit: int, offset: int) -> str:
+        return f'ARRAY_AGG({column} ORDER BY {order_by} LIMIT {limit})[SAFE_OFFSET({offset})]'
+    
+    def array_agg_ignore_nulls(self, column: str, order_by: str) -> str:
+        return f'ARRAY_AGG({column} IGNORE NULLS ORDER BY {order_by})'
+    
+    def count_if(self, condition: str) -> str:
+        return f'COUNTIF({condition})'
+    
+    def cast_to_string(self, column: str) -> str:
+        return f'CAST({column} AS STRING)'
+    
+    def safe_power(self, base: str, exponent: str) -> str:
+        return f'SAFE.POWER({base}, {exponent})'
+    
+    def safe_sqrt(self, value: str) -> str:
+        return f'SAFE.SQRT({value})'
+    
+    def generate_array(self, start: int, end: int) -> str:
+        return f'GENERATE_ARRAY({start}, {end})'
+    
+    def unnest_with_alias(self, array_expr: str, alias: str) -> str:
+        return f'UNNEST({array_expr}) AS {alias}'
+    
+    def nth_value_with_ignore_nulls(self, column: str, sort_by: str, n: int, ascending: bool = True) -> str:
+        order = '' if ascending else ' DESC'
+        # For dropna case: ARRAY_AGG(column IGNORE NULLS ORDER BY sort_by)[SAFE_OFFSET(n)]
+        return f'ARRAY_AGG({column} IGNORE NULLS ORDER BY {sort_by}{order})[SAFE_OFFSET({n})]'
+
+    def poisson_bootstrap_uniform_hash(self, columns: List[str]) -> str:
+        """Generate FARM_FINGERPRINT-based uniform random variable for BigQuery."""
+        cols_str = ', '.join(columns)
+        return f'FARM_FINGERPRINT(CONCAT({cols_str})) / 0xFFFFFFFFFFFFFFFF + 0.5'
+    
+    def select_all_except(self, excluded_columns: List[str]) -> str:
+        """Generate BigQuery EXCEPT syntax."""
+        excluded_str = ', '.join(excluded_columns)
+        return f'* EXCEPT({excluded_str})'
+
+
+class TrinoDialect(SqlDialect):
+    """Trino SQL dialect implementation.
+    
+    This implements Trino-specific SQL syntax to provide compatibility
+    with Trino/Presto SQL engines.
+    """
+    
+    @property
+    def name(self) -> str:
+        return "trino"
+    
+    def safe_divide(self, numerator: str, denominator: str) -> str:
+        return (f'CASE WHEN ({denominator}) = 0 THEN NULL '
+                f'ELSE CAST(({numerator}) AS DOUBLE) / CAST(({denominator}) AS DOUBLE) END')
+    
+    def approx_quantile(self, column: str, quantile: float) -> str:
+        return f'approx_percentile({column}, {quantile})'
+    
+    def array_agg_with_limit(self, column: str, order_by: str, limit: int, offset: int) -> str:
+        # Trino uses 1-based indexing for arrays
+        trino_index = offset + 1
+        return f'element_at(array_agg({column} ORDER BY {order_by}), {trino_index})'
+    
+    def array_agg_ignore_nulls(self, column: str, order_by: str) -> str:
+        return f'array_agg({column} ORDER BY {order_by}) FILTER (WHERE {column} IS NOT NULL)'
+    
+    def count_if(self, condition: str) -> str:
+        return f'COUNT(CASE WHEN {condition} THEN 1 END)'
+    
+    def cast_to_string(self, column: str) -> str:
+        return f'CAST({column} AS VARCHAR)'
+    
+    def safe_power(self, base: str, exponent: str) -> str:
+        # Trino doesn't have SAFE functions, but POWER handles most cases gracefully
+        return f'POWER({base}, {exponent})'
+    
+    def safe_sqrt(self, value: str) -> str:
+        # Use CASE to handle negative values gracefully
+        return f'CASE WHEN ({value}) >= 0 THEN SQRT({value}) ELSE NULL END'
+    
+    def generate_array(self, start: int, end: int) -> str:
+        return f'sequence({start}, {end})'
+    
+    def unnest_with_alias(self, array_expr: str, alias: str) -> str:
+        # Trino requires table alias format for UNNEST
+        return f'UNNEST({array_expr}) AS t({alias})'
+    
+    def nth_value_with_ignore_nulls(self, column: str, sort_by: str, n: int, ascending: bool = True) -> str:
+        order = '' if ascending else ' DESC'
+        # For dropna case: array_agg(column ORDER BY sort_by) FILTER (WHERE column IS NOT NULL) then element_at(..., n+1)
+        array_agg = f'array_agg({column} ORDER BY {sort_by}{order}) FILTER (WHERE {column} IS NOT NULL)'
+        return f'element_at({array_agg}, {n + 1})'
+
+    def poisson_bootstrap_uniform_hash(self, columns: List[str]) -> str:
+        """PoissonBootstrap with unit grouping is not supported in Trino."""
+        raise NotImplementedError(
+            'PoissonBootstrap with unit grouping requires FARM_FINGERPRINT function '
+            'which is not supported in Trino.'
+        )
+    
+    def select_all_except(self, excluded_columns: List[str]) -> str:
+        """PoissonBootstrap without pre-aggregation is not supported in Trino."""
+        raise NotImplementedError(
+            'PoissonBootstrap without pre-aggregation requires "* EXCEPT(...)" syntax '
+            'which is not supported in Trino.'
+        )
+
+
+# Global dialect configuration
+_available_dialects = {
+    'bigquery': BigQueryDialect(),
+    'trino': TrinoDialect()
+}
+_current_dialect = _available_dialects['bigquery']  # BigQuery as default
+
+
+# Public API functions
+def set_sql_dialect(dialect_name: str):
+    """Set the global SQL dialect.
+    
+    Args:
+        dialect_name: Name of the dialect to set ('bigquery', 'trino', etc.)
+        
+    Raises:
+        ValueError: If the dialect name is not available
+        
+    Example:
+        import meterstick as ms
+        ms.set_sql_dialect('trino')
+    """
+    global _current_dialect
+    if dialect_name not in _available_dialects:
+        available = list(_available_dialects.keys())
+        raise ValueError(
+            f"Unknown dialect: '{dialect_name}'. "
+            f"Available dialects: {available}"
+        )
+    _current_dialect = _available_dialects[dialect_name]
+
+
+def get_sql_dialect() -> SqlDialect:
+    """Get the current SQL dialect.
+    
+    Returns:
+        The currently active SqlDialect instance
+        
+    Example:
+        dialect = ms.get_sql_dialect()
+        sql = dialect.safe_divide('clicks', 'impressions')
+    """
+    return _current_dialect
+
+
+def get_available_sql_dialects() -> List[str]:
+    """Get list of available SQL dialect names.
+    
+    Returns:
+        List of available dialect names
+    """
+    return list(_available_dialects.keys())
+
+
+def register_sql_dialect(dialect: SqlDialect):
+    """Register a custom SQL dialect.
+    
+    Args:
+        dialect: Custom SqlDialect instance to register
+        
+    Raises:
+        ValueError: If a dialect with the same name is already registered
+        
+    Example:
+        class MyCustomDialect(ms.SqlDialect):
+            # ... implementation
+            pass
+            
+        ms.register_sql_dialect(MyCustomDialect())
+    """
+    if dialect.name in _available_dialects:
+        raise ValueError(f"Dialect '{dialect.name}' is already registered")
+    _available_dialects[dialect.name] = dialect 


### PR DESCRIPTION
## Context

Meterstick was originally designed for BigQuery and used BigQuery-specific SQL functions and syntax. This update introduces a SQL dialect system that maintains BigQuery compatibility while adding support for Trino SQL.

## High-Level Changes

### Core Architecture
- **New SQL Dialect System**: Simple global dialect registry with strategy pattern
- **Abstract Base Class**: `SqlDialect` defines interface for all SQL operations  
- **Concrete Implementations**: `BigQueryDialect` (default) and `TrinoDialect`
- **Global Configuration**: Simple module-level variables for easy configuration

### Key SQL Compatibility Changes

| Feature | BigQuery (Original) | Trino (New) |
|---------|---------------------|-------------|
| Division | `IF(denom = 0, NULL, num / denom)` | `CASE WHEN denom = 0 THEN NULL ELSE CAST(num AS DOUBLE) / CAST(denom AS DOUBLE) END` |
| Quantiles | `APPROX_QUANTILES(col, 100)[OFFSET(50)]` | `approx_percentile(col, 0.5)` |
| Array Indexing | `ARRAY_AGG(...)[SAFE_OFFSET(n)]` | `element_at(array_agg(...), n+1)` |
| Conditional Count | `COUNTIF(condition)` | `COUNT(CASE WHEN condition THEN 1 END)` |
| Array Operations | `UNNEST(array) AS alias` | `UNNEST(array) AS t(alias)` |
| String Casting | `CAST(col AS STRING)` | `CAST(col AS VARCHAR)` |
| String Literal | Both double quotes and single quotes | Single quotes only |
| PoissonBootstrap Hash | `FARM_FINGERPRINT(CONCAT(...))` | (raise `NotImplementedError`) |
| Column Exclusion | `* EXCEPT(col1, col2)` | (raise `NotImplementedError`) |

### Files Modified
- **`sql_dialect.py`** ✨ *NEW*: Core dialect system with `SqlDialect` base class, `BigQueryDialect`, `TrinoDialect`, and API functions
- **`sql.py`**: 
  - Converted `SAFE_DIVIDE` constant to dialect-aware template object maintaining original `.format(numer=..., denom=...)` syntax
  - Added dialect-aware `safe_power`/`safe_sqrt` operations in Column class
  - Updated string casting to use dialect-specific syntax
- **`metrics.py`**: 
  - `Nth` class: Replaced BigQuery-specific array operations with dialect-aware `nth_value_with_ignore_nulls` and `array_agg_with_limit`  
  - `Quantile` class: Replaced `APPROX_QUANTILES` with dialect-aware `approx_quantile`
- **`operations.py`**: 
  - Added dialect-aware methods: `poisson_bootstrap_uniform_hash()` and `select_all_except()`
- **`diversity.py`**: 
  - `TopK` class: Updated UNNEST syntax using dialect-aware `unnest_with_alias`
  - `Nxx` class: Converted `COUNTIF` to dialect-aware `count_if`
- **`models.py`**: Updated `LogisticRegression` to use dialect-aware `count_if` instead of `COUNTIF`
- **`__init__.py`**: Added wildcard import from `sql_dialect` module
- **`README.md`**: Added comprehensive SQL dialect section with usage examples and supported dialects list

All the string literal formatting are changed to single quotes to be compatible with both SQL dialects

## Design Principles

1. **Backwards Compatibility**: BigQuery remains default dialect
2. **Extensibility**: Easy to add new dialects (PostgreSQL, Snowflake, etc.)
3. **Centralized Logic**: Single source of truth for SQL generation patterns

## API Usage

```python
import meterstick as ms

# Create a metric that uses division and quantiles
metric = ms.MetricList([
    ms.Sum('clicks') / ms.Sum('impressions'),  # Uses SAFE_DIVIDE template automatically
    ms.Quantile('revenue', 0.5)               # Uses dialect-aware quantile function
])

# Default BigQuery SQL
print("BigQuery SQL:")
print(metric.to_sql('events'))
# Output includes: IF((SUM(impressions)) = 0, NULL, (SUM(clicks)) / (SUM(impressions)))
#                  APPROX_QUANTILES(revenue, 100)[OFFSET(50)]

# Switch to Trino
ms.set_sql_dialect('trino')
print("\nTrino SQL:")
print(metric.to_sql('events'))  
# Output includes: CASE WHEN (SUM(impressions)) = 0 THEN NULL ELSE CAST((SUM(clicks)) AS DOUBLE) / CAST((SUM(impressions)) AS DOUBLE) END
#                  approx_percentile(revenue, 0.5)

# Register custom dialect
class CustomDialect(ms.SqlDialect):
    # ... implementation
ms.register_sql_dialect(CustomDialect())
```

## Dialect-Specific Error Handling

The system now uses proper abstraction for dialect-specific features:

- **PoissonBootstrap**: 
  - `poisson_bootstrap_uniform_hash()`: BigQuery implements FARM_FINGERPRINT; Trino raises informative NotImplementedError
  - `select_all_except()`: BigQuery implements "* EXCEPT(...)"; Trino raises informative NotImplementedError  
  - **No more explicit dialect checks in operations.py** - errors are raised at the dialect level
