### PR TITLE
fix: replace absltest with absl-py (dependency confusion)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-absltest
+absl-py
 six
 numpy>=2.0.0
 scipy>=1.9.3


### PR DESCRIPTION
`absltest` in `requirements.txt` is not a registered PyPI package. It is `absl.testing.absltest`, a class inside the `absl-py` package (Google's Python port of Abseil). The correct dependency is `absl-py`.

As-is, `pip install -r requirements.txt` attempts to resolve `absltest` from PyPI. If an attacker registers that name, any contributor setting up the development environment would install the malicious package.

This PR replaces `absltest` with `absl-py`.
